### PR TITLE
MAINT: Fix test save paths

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       max-parallel: 100
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.11", "3.12", "3.13"]
         pycalphad_develop_version: [true, false]
 
     steps:

--- a/kawin/tests/test_PBM.py
+++ b/kawin/tests/test_PBM.py
@@ -89,7 +89,7 @@ def test_DT():
     calcDT = pbm.getDTEuler(5, growth, dissIndex, maxBinRatio=ratio)
     assert_allclose(trueDT, calcDT, rtol=1e-6)
 
-def test_PBMrecording():
+def test_PBMrecording(tmpdir):
     pbm = PopulationBalanceModel(cMin=1e-10, cMax=1e-8, bins=100, minBins=50, maxBins=150, record=True)
 
     pbm.PSD[10:20] = 2
@@ -131,11 +131,10 @@ def test_PBMrecording():
 
     pbm.record(7)
 
-    pbm.saveRecordedPSD('kawin/tests/pbm.npz')
+    pbm.saveRecordedPSD(tmpdir / 'pbm.npz')
 
     new_pbm = PopulationBalanceModel(cMin=1e-10, cMax=1e-8, bins=100, minBins=50, maxBins=150, record=True)
-    new_pbm.loadRecordedPSD('kawin/tests/pbm.npz')
-    os.remove('kawin/tests/pbm.npz')
+    new_pbm.loadRecordedPSD(tmpdir / 'pbm.npz')
 
     # Interpolate between time when we first add bins, so last bin should be ~1.25 of original
     pbm.setPSDtoRecordedTime(2.5)

--- a/kawin/tests/test_diffusion.py
+++ b/kawin/tests/test_diffusion.py
@@ -21,8 +21,8 @@ FeCTherm = GeneralThermodynamics(FECRC_DB, ['FE', 'C'], ['FCC_A1'])
 def test_compositionInput():
     '''
     Tests that after setting up a model, all components are greater than 0
-    
-    In practice, this greatly speeds up simulation time without sacrificing accuracy since it avoids 
+
+    In practice, this greatly speeds up simulation time without sacrificing accuracy since it avoids
     performing equilibrium calculations with a composition of 0 for any given component
 
     The composition and setup functions for both models inherit from the
@@ -31,7 +31,7 @@ def test_compositionInput():
     N = 100
     profile = ProfileBuilder()
     profile.addBuildStep(StepProfile1D(0, [0.2, 0.8], [1, 0]), ['CR', 'AL'])
-    
+
     mesh = Cartesian1D(['CR', 'AL'], [-1e-3, 1e-3], N)
     mesh.setResponseProfile(profile)
     model = SinglePhaseModel(mesh, ['NI', 'CR', 'AL'], ['FCC_A1'], NiCrAlTherm, TemperatureParameters(1200+273.15))
@@ -93,7 +93,7 @@ def test_homogenizationMobility():
 
 def test_homogenizationSinglePhaseMobility():
     '''
-    Tests that in a single phase region, any of the mobility functions will give 
+    Tests that in a single phase region, any of the mobility functions will give
     the same mobility of the single phase itself
     '''
     x = [0.05, 0.05]
@@ -103,8 +103,8 @@ def test_homogenizationSinglePhaseMobility():
     homogenizationParameters.labyrinthFactor = 2
     mob_data = computeMobility(NiCrAlTherm, x, T)
 
-    mob_funcs = [HomogenizationParameters.WIENER_UPPER, HomogenizationParameters.WIENER_LOWER, 
-                 HomogenizationParameters.HASHIN_UPPER, HomogenizationParameters.HASHIN_LOWER, 
+    mob_funcs = [HomogenizationParameters.WIENER_UPPER, HomogenizationParameters.WIENER_LOWER,
+                 HomogenizationParameters.HASHIN_UPPER, HomogenizationParameters.HASHIN_LOWER,
                  HomogenizationParameters.LABYRINTH]
     for f in mob_funcs:
         homogenizationParameters.setHomogenizationFunction(f)
@@ -139,7 +139,7 @@ def test_homogenization_wiener_lower():
 
     homogenizationParameters = HomogenizationParameters()
     homogenizationParameters.setHomogenizationFunction(HomogenizationParameters.WIENER_LOWER)
-    
+
     mob, _ = computeHomogenizationFunction(NiCrAlTherm, x1, T, homogenizationParameters)
     assert_allclose(mob, [3.927302e-22, 2.323337e-23, 6.206029e-23], atol=0, rtol=1e-3)
 
@@ -156,7 +156,7 @@ def test_homogenization_hashin_upper():
 
     homogenizationParameters = HomogenizationParameters()
     homogenizationParameters.setHomogenizationFunction(HomogenizationParameters.HASHIN_UPPER)
-    
+
     mob, _ = computeHomogenizationFunction(NiCrAlTherm, x1, T, homogenizationParameters)
     assert_allclose(mob, [3.927302e-22, 2.323337e-23, 6.206029e-23], atol=0, rtol=1e-3)
 
@@ -173,7 +173,7 @@ def test_homogenization_hashin_lower():
 
     homogenizationParameters = HomogenizationParameters()
     homogenizationParameters.setHomogenizationFunction(HomogenizationParameters.HASHIN_LOWER)
-    
+
     mob, _ = computeHomogenizationFunction(NiCrAlTherm, x1, T, homogenizationParameters)
     assert_allclose(mob, [3.927302e-22, 2.323337e-23, 6.206029e-23], atol=0, rtol=1e-3)
 
@@ -193,7 +193,7 @@ def test_homogenization_lab():
     # Labyrinth factor is clipped to [1,2]
     homogenizationParameters.setLabyrinthFactor(2.3)
     assert homogenizationParameters.labyrinthFactor == 2
-    
+
     mob, _ = computeHomogenizationFunction(NiCrAlTherm, x1, T, homogenizationParameters)
     assert_allclose(mob, [3.927302e-22, 2.323337e-23, 6.206029e-23], atol=0, rtol=1e-3)
 
@@ -210,7 +210,7 @@ def test_homogenization_post_process():
     '''
     x = [0.5, 0.18]
     T = 1073
-    
+
     homogenizationParameters = HomogenizationParameters()
     hashTable = HashTable()
 
@@ -234,7 +234,7 @@ def test_homogenization_post_process():
         fcc_index = np.squeeze(np.where(mob.phases == 'FCC_A1')[0])
         sigma_index = np.squeeze(np.where(mob.phases == 'SIGMA')[0])
         mob, phase_fracs = homogenizationParameters.postProcessFunction(mob, *homogenizationParameters.postProcessParameters)
-        
+
         assert_allclose(mob[fcc_index], p[2]['FCC_A1'], rtol=1e-3)
         assert_allclose(mob[sigma_index], p[2]['SIGMA'], rtol=1e-3)
 
@@ -285,7 +285,7 @@ def test_single_phase_dxdt():
         m.setup()
         dxdt = m.getdXdt(m.currentTime, m.getCurrentX())
         dt = m.getDt(dxdt)
-        
+
         print(dxdt[0][5], dxdt[0][10], dxdt[0][15], dt)
         assert_allclose(dxdt[0][5], vals5[i], rtol=1e-3)
         assert_allclose(dxdt[0][10], vals10[i], rtol=1e-3)
@@ -313,7 +313,7 @@ def test_diffusion_x_shape():
 
     x = m.getCurrentX()
     origShape = x[0].shape
-    
+
     x_flat = m.flattenX(x)
     flatShape = x_flat.shape
 
@@ -330,8 +330,8 @@ def test_homogenization_dxdt():
     Check flux values of arbitrary homogenization model problem
 
     We spot check a few points on dxdt rather than checking the entire array
-    
-    We'll only test using the hashin lower homogenization function since there's already tests for 
+
+    We'll only test using the hashin lower homogenization function since there's already tests for
     the output of each homogenization function
 
     This uses the parameters from 07_Homogenization_Model example with the compositions
@@ -347,7 +347,7 @@ def test_homogenization_dxdt():
     mesh.setResponseProfile(profile)
     homogenizationParameters = HomogenizationParameters(HomogenizationParameters.HASHIN_LOWER, eps=0.01)
 
-    m = HomogenizationModel(mesh,  ['FE', 'CR', 'NI'], ['FCC_A1', 'BCC_A2'], 
+    m = HomogenizationModel(mesh,  ['FE', 'CR', 'NI'], ['FCC_A1', 'BCC_A2'],
                             thermodynamics=FeCrNiTherm, temperature=TemperatureParameters(1373.15),
                             homogenizationParameters=homogenizationParameters)
     m.constraints.maxCompositionChange = 0.002
@@ -355,7 +355,7 @@ def test_homogenization_dxdt():
     m.setup()
     dxdt = m.getdXdt(m.currentTime, m.getCurrentX())
     dt = m.getDt(dxdt)
-    
+
     # #Index 5
     ind5, vals5 = 5, np.array([-1.41988464e-09, 1.23824350e-09])
 
@@ -375,7 +375,7 @@ def test_homogenization_dxdt():
     mesh = Cartesian1D(['CR', 'NI'], [-5e-4, 5e-4], 20)
     mesh.setResponseProfile(profile)
     homogenizationParameters = HomogenizationParameters(HomogenizationParameters.HASHIN_UPPER, eps=0.01)
-    m = HomogenizationModel(mesh,  ['FE', 'CR', 'NI'], ['FCC_A1', 'BCC_A2'], 
+    m = HomogenizationModel(mesh,  ['FE', 'CR', 'NI'], ['FCC_A1', 'BCC_A2'],
                             thermodynamics=FeCrNiTherm, temperature=TemperatureParameters(1373.15),
                             homogenizationParameters=homogenizationParameters)
     m.constraints.maxCompositionChange = 0.002
@@ -387,7 +387,7 @@ def test_homogenization_dxdt():
 
     # The dxdt values are changed due to a correction in how the mobility for each phase is computed
     # Before, the mobilities were multiplied by the overall composition rather than the phase composition
-    
+
     #Index 5
     ind5, vals5 = 5, np.array([-2.8577719e-8, -4.66806883e-9])
 
@@ -396,14 +396,14 @@ def test_homogenization_dxdt():
 
     #Index 15
     ind15, vals15 = 15, np.array([-1.62720361e-8, -7.03752829e-9])
-    
+
     print(dxdt[0][ind5], dxdt[0][ind10], dxdt[0][ind15], dt)
     assert_allclose(dxdt[0][ind5], vals5, atol=0, rtol=1e-3)
     assert_allclose(dxdt[0][ind10], vals10, atol=0, rtol=1e-3)
     assert_allclose(dxdt[0][ind15], vals15, atol=0, rtol=1e-3)
     assert_allclose(dt, 3348.705601, rtol=1e-3)
 
-def test_diffusionSavingLoading():
+def test_diffusionSavingLoading(tmpdir):
     '''
     Tests saving/loading behavior of diffusion model
     '''
@@ -414,18 +414,17 @@ def test_diffusionSavingLoading():
     mesh.setResponseProfile(profile)
 
     #Define mesh spanning between -1mm to 1mm with 50 volume elements
-    m = SinglePhaseModel(mesh, ['NI', 'CR', 'AL'], ['FCC_A1'], 
+    m = SinglePhaseModel(mesh, ['NI', 'CR', 'AL'], ['FCC_A1'],
                          thermodynamics=NiCrAlTherm,
                          temperature=temperature, record=True)
 
     m.solve(10*3600, verbose=True, vIt=1)
-    m.save('kawin/tests/diff.npz')
+    m.save(tmpdir / 'diff.npz')
 
-    new_m = SinglePhaseModel(mesh, ['NI', 'CR', 'AL'], ['FCC_A1'], 
+    new_m = SinglePhaseModel(mesh, ['NI', 'CR', 'AL'], ['FCC_A1'],
                          thermodynamics=NiCrAlTherm,
                          temperature=temperature, record=True)
-    new_m.load('kawin/tests/diff.npz')
-    os.remove('kawin/tests/diff.npz')
+    new_m.load(tmpdir / 'diff.npz')
 
     #assert_allclose(m.mesh.y, new_m.mesh.y)
     assert_allclose(m.data.currentY, new_m.data.currentY)

--- a/kawin/tests/test_precipitation.py
+++ b/kawin/tests/test_precipitation.py
@@ -74,7 +74,7 @@ def test_binary_precipitation_dxdt():
 
     #Set arbitrary final time, this is done during the solve function, but we do it here since we're not using the solve function
     #  the initial guess for the time step will be 0.01*(1.001) regardless of finalTime
-    model.finalTime = 1 
+    model.finalTime = 1
     dt = model.getDt(dxdt)
 
     indices = [10, 20, 30]
@@ -128,7 +128,7 @@ def test_multi_precipitation_dxdt():
 
     #Set arbitrary final time, this is done during the solve function, but we do it here since we're not using the solve function
     #  the initial guess for the time steo will be 0.01*(1.001) regardless of finalTime
-    model.finalTime = 1 
+    model.finalTime = 1
     dt = model.getDt(dxdt)
 
     indices = [10, 20, 30]
@@ -192,7 +192,7 @@ def test_multiphase_precipitation_x_shape():
     assert(len(x_restore) == origLen)
     assert(np.all(psd.shape == (bins,) for psd in x_restore))
 
-def test_precipitationSavingLoading():
+def test_precipitationSavingLoading(tmpdir):
     '''
     Test saving loading behavior
     '''
@@ -224,11 +224,10 @@ def test_precipitationSavingLoading():
     model = PrecipitateModel(matrix=matrix, precipitates=precipitates, thermodynamics=AlMgSitherm, temperature=temperature)
     model.solve(0.1, verbose=True, vIt=1)
 
-    model.save('kawin/tests/prec.npz')
+    model.save(tmpdir / 'prec.npz')
 
     new_model = PrecipitateModel(matrix=matrix, precipitates=precipitates, thermodynamics=AlMgSitherm, temperature=temperature)
-    new_model.load('kawin/tests/prec.npz')
-    os.remove('kawin/tests/prec.npz')
+    new_model.load(tmpdir / 'prec.npz')
 
     assert_allclose(model.data.Ravg, new_model.data.Ravg)
     assert_allclose(model.data.time, new_model.data.time)
@@ -257,7 +256,7 @@ def test_precipitationCoupling():
     model.setPBMParameters(cMin=1e-10, cMax=1e-8, bins=75, minBins=50, maxBins=100)
 
     grainModel = GrainGrowthModel(gbe=0.5, M=1e-14)
-    
+
     coh = CoherencyContribution(0.01, 'AL3ZR')
     dislocations = DislocationParameters(G=50e9, b=1e-9, nu=1/3)
     ss = SolidSolutionStrength({'ZR': 1e9})
@@ -378,7 +377,7 @@ def test_precipitationStopping():
     model.setup()
     _, stop = model.postProcess(0.1, [p.PSD for p in model.PBM])
     assert stop
-    
+
     # 'and' needs all conditions to be true to stop
     model.reset()
     model.clearStoppingConditions()
@@ -407,10 +406,8 @@ def test_ttp():
     model = PrecipitateModel(matrix, precipitate, AlZrTherm, T)
     model.setPBMParameters(cMin=1e-10, cMax=1e-8, bins=75, minBins=50, maxBins=100)
     volCond = VolumeFractionCondition(Inequality.GREATER_THAN, -1)
-    
+
     # Tests that the TTP can be ran and plotted
     ttp = TTPCalculator(model, volCond)
     ttp.calculateTTP(500, 600, 3, 10)
     plotTTP(ttp)
-
-

--- a/kawin/tests/test_surrogate.py
+++ b/kawin/tests/test_surrogate.py
@@ -107,7 +107,7 @@ def test_Surr_binary_Diff_output():
     #Compare to Thermodynamics, high tolerance since we're just checking that functions are interchangeable
     assert_allclose(dnkj, dnkjT, atol=0, rtol=1e-1)
 
-def test_Surr_binary_save():
+def test_Surr_binary_save(tmpdir):
     '''
     Checks that binary surrogate can be saved and loaded to get same values
     '''
@@ -126,23 +126,21 @@ def test_Surr_binary_save():
     c, d = surr.getInterfacialComposition(T, 500)
     e = surr.getInterdiffusivity(0.1, T + 50)
 
-    surr.toJson('kawin/tests/alzr.json')
+    surr.toJson(tmpdir / 'alzr.json')
 
-    #surr2 = BinarySurrogate.load('kawin/tests/alzr')
+    #surr2 = BinarySurrogate.load(tmpdir / 'alzr')
     surr2 = BinarySurrogate(AlZrTherm)
-    surr2.fromJson('kawin/tests/alzr.json')
+    surr2.fromJson(tmpdir / 'alzr.json')
     a2, b2 = surr2.getDrivingForce(0.004, T)
     c2, d2 = surr2.getInterfacialComposition(T, 500)
     e2 = surr2.getInterdiffusivity(0.1, T + 50)
-
-    os.remove('kawin/tests/alzr.json')
 
     # assert that models will generated from json data
     assert 'FCC_A1' in surr2.diffusivityModels
     assert 'AL3ZR' in surr2.drivingForceModels
     assert_allclose([a, b, c, d, e], [a2, b2, c2, d2, e2], rtol=1e-3)
 
-def test_Surr_binary_save_missing():
+def test_Surr_binary_save_missing(tmpdir):
     '''
     Checks that load function will not fail if one of the three surrogates are not trained yet
     '''
@@ -153,14 +151,12 @@ def test_Surr_binary_save_missing():
 
     a, b = surr.getDrivingForce(0.004, T)
 
-    surr.toJson('kawin/tests/alzr.json')
+    surr.toJson(tmpdir / 'alzr.json')
 
-    #surr2 = BinarySurrogate.load('kawin/tests/alzr')
+    #surr2 = BinarySurrogate.load(tmpdir / 'alzr')
     surr2 = BinarySurrogate(AlZrTherm)
-    surr2.fromJson('kawin/tests/alzr.json')
+    surr2.fromJson(tmpdir / 'alzr.json')
     a2, b2 = surr2.getDrivingForce(0.004, T)
-
-    os.remove('kawin/tests/alzr.json')
 
     assert 'AL3ZR' in surr2.drivingForceModels
     assert_allclose(a, a2, atol=0, rtol=1e-3)
@@ -228,7 +224,7 @@ def test_Surr_ternary_IC_output():
     assert_allclose(ca, caT, atol=0, rtol=1e-1)
     assert_allclose(cb, cbT, atol=0, rtol=1e-1)
 
-def test_Surr_ternary_save():
+def test_Surr_ternary_save(tmpdir):
     '''
     Checks that multicomponent surrogate can be saved and loaded
     '''
@@ -243,22 +239,20 @@ def test_Surr_ternary_save():
     g, ca, cb, _, _ = surr.getGrowthAndInterfacialComposition([0.08, 0.1], T[0]+25, 900, 1e-9, 1000)
     beta = surr.impingementFactor([0.08, 0.1], T[0]+25)
 
-    surr.toJson('kawin/tests/nicral.json')
+    surr.toJson(tmpdir / 'nicral.json')
 
-    #surr2 = MulticomponentSurrogate.load('kawin/tests/nicral')
+    #surr2 = MulticomponentSurrogate.load(tmpdir / 'nicral')
     surr2 = MulticomponentSurrogate(NiCrAlTherm)
-    surr2.fromJson('kawin/tests/nicral.json')
+    surr2.fromJson(tmpdir / 'nicral.json')
     a2, b2 = surr2.getDrivingForce([0.08, 0.1], T[0]+25)
     g2, ca2, cb2, _, _ = surr2.getGrowthAndInterfacialComposition([0.08, 0.1], T[0]+25, 900, 1e-9, 1000)
     beta2 = surr2.impingementFactor([0.08, 0.1], T[0]+25)
-
-    os.remove('kawin/tests/nicral.json')
 
     assert 'FCC_L12' in surr2.drivingForceModels
     assert 'FCC_L12' in surr2.curvatureModels
     assert_allclose([a, b[0], b[1], g, ca[0], ca[1], cb[0], cb[1], beta], [a2, b2[0], b2[1], g2, ca2[0], ca2[1], cb2[0], cb2[1], beta2], atol=0, rtol=1e-3)
 
-def test_Surr_ternary_save_missing():
+def test_Surr_ternary_save_missing(tmpdir):
     '''
     Checks that load function will not fail if one of the three surrogates are not trained yet
     '''
@@ -268,13 +262,12 @@ def test_Surr_ternary_save_missing():
     surr.trainDrivingForce(x, T)
 
     a, b = surr.getDrivingForce([0.08, 0.1], T[0]+25)
-    surr.toJson('kawin/tests/nicral.json')
+    surr.toJson(tmpdir / 'nicral.json')
 
-    #surr2 = MulticomponentSurrogate.load('kawin/tests/nicral')
+    #surr2 = MulticomponentSurrogate.load(tmpdir / 'nicral')
     surr2 = MulticomponentSurrogate(NiCrAlTherm)
-    surr2.fromJson('kawin/tests/nicral.json')
+    surr2.fromJson(tmpdir / 'nicral.json')
     a2, b2 = surr2.getDrivingForce([0.08, 0.1], T[0]+25)
-    os.remove('kawin/tests/nicral.json')
 
     assert 'FCC_L12' in surr2.drivingForceModels
     assert_allclose([a, b[0], b[1]], [a2, b2[0], b2[1]], atol=0, rtol=1e-3)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
 ]
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 dependencies = [
     "matplotlib>=3.3",
     "numpy>=2.0",


### PR DESCRIPTION
Paths should be more general so pytest can be run from any location.
Uses pytest built-in fixtures for `tmpdir`.

Updates the code so that we can take pathlib.Path objects and convert them to strings

Drops Python 3.10 support following [NEP-29](https://numpy.org/neps/nep-0029-deprecation_policy.html)